### PR TITLE
use Keepalive agent by default.

### DIFF
--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -6,10 +6,12 @@
  */
 
 var http = require('http');
+var KeepaliveAgent = require('agentkeepalive');
 
-// change Agent.maxSockets to 1000
-exports.agent = new http.Agent();
-exports.agent.maxSockets = 1000;
+exports.agent = new KeepaliveAgent({
+  maxSockets: 200,
+  maxKeepAliveTime: 60000 // max keep alive time
+});
 
 exports.create = function (options) {
   return new Client(options || {});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "itier",
     "client"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "agentkeepalive": ">=0.1.3"
+  },
   "engines": {
     "node": ">=0.6.6"
   },
@@ -31,6 +33,9 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/aleafs/itier-client.git"
+  },
+  "bugs": {
+    "url": "https://github.com/aleafs/itier-client/issues"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
I think is time to use keepalive agent by default.
I have use `agentkeepalive` on my application more than a week.

benchmark result on stg:

before:
![http://ww1.sinaimg.cn/large/6cfc7910jw1dwfomzu0c3j.jpg](http://ww1.sinaimg.cn/large/6cfc7910jw1dwfomzu0c3j.jpg)

after:
![http://ww3.sinaimg.cn/large/6cfc7910jw1dwfonxak1lj.jpg](http://ww3.sinaimg.cn/large/6cfc7910jw1dwfonxak1lj.jpg)
