### PR TITLE
itier-client support iservice-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib-cov
 coverage.html
+test/run

--- a/README.md
+++ b/README.md
@@ -46,14 +46,17 @@ var itier = require('itier').createClient({
   timeout: 5000, // 5 seconds
 });
 
-// connect iservice and connect itier
-// if obj is null, you must have used connect api
-var obj = itier.connectIservice({
-  host : '127.0.0.1:9999',
-  cache : __dirname + '/cache'
-});
+//use iservice to create a service obj
+var itierObj = require('iservice-client').init({
+  host : '127.0.0.1:12345', //iservice address
+  cache : __dirname + '/run', //iservice cache address
+}).createService().subscribe('itier');
 
-obj.on('ready', function () {
+// when ready event is emitted, add iservice object into itier client.
+// then do anything you want
+itierObj.on('ready', function () {
+  itier.useIservice(itierObj);
+
   //do query
   itier.query('SELECT * FROM table WHERE c1 = :c', { 
     'c' : 1211 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,36 @@ itier.query('SELECT * FROM table WHERE c1 = :c', {
 itier.status('lastdate', function(error, status) {
   console.log(status);
 });
+
+
+
+//how to use itier-client with iservice
+var itier = require('itier').createClient({
+  appname: 'appname',
+  password: 'password',
+  timeout: 5000, // 5 seconds
+});
+
+// connect iservice and connect itier
+var obj = itier.connectIservice({
+  host : '127.0.0.1:9999',
+  cache : __dirname + '/cache'
+});
+
+obj.on('ready', function () {
+  //do query
+  itier.query('SELECT * FROM table WHERE c1 = :c', { 
+    'c' : 1211 
+  }, function(error, data, header, profile) {
+    if (error) {
+      throw new Error(error);
+    }
+
+    // write to cache
+    cache.write(key, data, header.expire + now);
+  });
+});
+
 ```
 
 # TODO

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ var itier = require('itier').createClient({
 });
 
 // connect iservice and connect itier
+// if obj is null, you must have used connect api
 var obj = itier.connectIservice({
   host : '127.0.0.1:9999',
   cache : __dirname + '/cache'

--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -112,15 +112,15 @@ Client.prototype.bind = function (host, port) {
 /* }}} */
 
 /* {{{ Client prototype get() */
-Client.prototype.get = function (url, callback, headers) {
-  this._call(this._host(), 'GET', url, null, headers, callback);
+Client.prototype.get = function (url, callback, headers, hostObj) {
+  this._call(hostObj || this._host(), 'GET', url, null, headers, callback);
   return this;
 }
 /* }}} */
 
 /* {{{ Client prototype post() */
-Client.prototype.post = function (url, data, callback, headers) {
-  this._call(this._host(), 'POST', url, data, headers, callback);
+Client.prototype.post = function (url, data, callback, headers, hostObj) {
+  this._call(hostObj || this._host(), 'POST', url, data, headers, callback);
   return this;
 }
 /* }}} */

--- a/lib/itier-client.js
+++ b/lib/itier-client.js
@@ -81,22 +81,9 @@ Itier.prototype.connectIservice = function (options) {
   }
   this.useIservice = true;
 
-  var retObj = new EventEmitter();
-
-  var obj = IserviceClient.init(options);
-  obj.on('ready', function () {
-    _self.itier = IserviceClient.createService().subscribe('itier');
-    _self.itier.on('ready', function () {
-      retObj.emit('ready');
-    });
-    _self.itier.on('error', function (err) {
-      retObj.emit('error', err);
-    });
-    _self.itier.on('change', function () {
-      retObj.emit('change', _self.itier.getAll());
-    });
-  });
-  return retObj;
+  IserviceClient.init(options);
+  this.itier = IserviceClient.createService().subscribe('itier');
+  return this.itier;
 }
 /*}}}*/
 

--- a/lib/itier-client.js
+++ b/lib/itier-client.js
@@ -5,7 +5,9 @@
  * @author: zhangxc83@gmail.com
  */
 
+var EventEmitter = require('events').EventEmitter;
 var Client  = require(__dirname + '/http-client.js');
+var IserviceClient = require('iservice-client');
 var VERSION = require(__dirname + '/../package.json').version;
 
 /**
@@ -59,6 +61,7 @@ function Itier(options) {
     'heartbeat' : 10000,
     'pingurl'   : '/status.taobao'
   };
+
   for (var i in options) {
     this.options[i] = options[i];
   }
@@ -70,8 +73,39 @@ function Itier(options) {
 }
 /* }}} */
 
+/*{{{ Itier prototype connectIservice() */
+Itier.prototype.connectIservice = function (options) {
+  var _self = this;
+  if (this.useIservice === false) {
+    return null;
+  }
+  this.useIservice = true;
+
+  var retObj = new EventEmitter();
+
+  var obj = IserviceClient.init(options);
+  obj.on('ready', function () {
+    _self.itier = IserviceClient.createService().subscribe('itier');
+    _self.itier.on('ready', function () {
+      retObj.emit('ready');
+    });
+    _self.itier.on('error', function (err) {
+      retObj.emit('error', err);
+    });
+    _self.itier.on('change', function () {
+      retObj.emit('change', _self.itier.getAll());
+    });
+  });
+  return retObj;
+}
+/*}}}*/
+
 /* {{{ Itier prototype connect() */
 Itier.prototype.connect = function (host, port) {
+  if (this.useIservice === true) {
+    return null;
+  }
+  this.useIservice = false;
   this.client.bind(host, port || 80);
   return this;
 };
@@ -203,7 +237,7 @@ Itier.prototype.query = function (sql, data, callback, extra, fetchmode) {
       data = build_itier_data(body.d, body.f);
     }
     callback(null, data, infos, []);
-  }, options);
+  }, options, this.itier ? this.itier.get() : null);
 
   return this;
 };
@@ -230,7 +264,7 @@ Itier.prototype.status = function (name, callback) {
       });
     }
     callback(error, rows);
-  });
+  }, null, this.itier ? this.itier.get() : null);
 };
 /* }}} */
 
@@ -261,7 +295,7 @@ Itier.prototype.explain = function (sql, data, callback) {
         if ((--_waits) === 0) {
           callback(null, plans);
         }
-      });
+      }, null, this.itier ? this.itier.get() : null);
     });
 
     if (!_waits) {

--- a/lib/itier-client.js
+++ b/lib/itier-client.js
@@ -74,25 +74,13 @@ function Itier(options) {
 /* }}} */
 
 /*{{{ Itier prototype connectIservice() */
-Itier.prototype.connectIservice = function (options) {
-  var _self = this;
-  if (this.useIservice === false) {
-    return null;
-  }
-  this.useIservice = true;
-
-  IserviceClient.init(options);
-  this.itier = IserviceClient.createService().subscribe('itier');
-  return this.itier;
+Itier.prototype.useIservice = function (service) {
+  this.service = service;
 }
 /*}}}*/
 
 /* {{{ Itier prototype connect() */
 Itier.prototype.connect = function (host, port) {
-  if (this.useIservice === true) {
-    return null;
-  }
-  this.useIservice = false;
   this.client.bind(host, port || 80);
   return this;
 };
@@ -224,7 +212,7 @@ Itier.prototype.query = function (sql, data, callback, extra, fetchmode) {
       data = build_itier_data(body.d, body.f);
     }
     callback(null, data, infos, []);
-  }, options, this.itier ? this.itier.get() : null);
+  }, options, this.service ? this.service.get() : null);
 
   return this;
 };
@@ -251,7 +239,7 @@ Itier.prototype.status = function (name, callback) {
       });
     }
     callback(error, rows);
-  }, null, this.itier ? this.itier.get() : null);
+  }, null, this.service ? this.service.get() : null);
 };
 /* }}} */
 
@@ -282,7 +270,7 @@ Itier.prototype.explain = function (sql, data, callback) {
         if ((--_waits) === 0) {
           callback(null, plans);
         }
-      }, null, this.itier ? this.itier.get() : null);
+      }, null, this.service ? this.service.get() : null);
     });
 
     if (!_waits) {

--- a/lib/itier-client.js
+++ b/lib/itier-client.js
@@ -7,7 +7,6 @@
 
 var EventEmitter = require('events').EventEmitter;
 var Client  = require(__dirname + '/http-client.js');
-var IserviceClient = require('iservice-client');
 var VERSION = require(__dirname + '/../package.json').version;
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itier",
-  "version": "0.1.9",
+  "version": "0.1.8",
   "author": "Aleafs Zhang (zhangxc83@gmail.com)",
   "contributors": [
     "Aleafs Zhang <zhangxc83@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itier",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "author": "Aleafs Zhang (zhangxc83@gmail.com)",
   "contributors": [
     "Aleafs Zhang <zhangxc83@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "main": "./index.js",
   "devDependencies": {
-    "iservice-client": "=0.0.16",
+    "iservice-client": "=0.0.18",
     "should": ">=0.4.2",
     "mocha": ">=0.9.0",
     "visionmedia-jscoverage": "*"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "main": "./index.js",
   "devDependencies": {
+    "iservice-client": "=0.0.16",
     "should": ">=0.4.2",
     "mocha": ">=0.9.0",
     "visionmedia-jscoverage": "*"

--- a/test/itier-client-test.js
+++ b/test/itier-client-test.js
@@ -4,6 +4,7 @@ var should  = require('should');
 var ITier   = require(__dirname + '/../');
 var pedding = require('./utils/pedding');
 var http    = require('http');
+var Iservice = require('iservice-client');
 
 /* {{{ mock itier service on 33750 */
 var HTTP    = require('http').createServer(function (req, res) {
@@ -520,13 +521,15 @@ describe('itier-client-with-iservice-works-fine', function () {
       client = ITier.createClient({
         'appname' : 'test',
       });
-      var obj = client.connectIservice({
+      var obj = Iservice.init({
         host : '127.0.0.1:23432',
         cache : __dirname + '/run',
         //用户使用时，不设置not_copy
         not_copy : true,
-      });
+      }).createService().subscribe('itier');
+
       obj.on('ready', function () {
+        client.useIservice(obj);
         done();
       });
     });

--- a/test/itier-client-test.js
+++ b/test/itier-client-test.js
@@ -449,59 +449,14 @@ describe('itier-client-test', function () {
 /*{{{ itier-client-with-iservice-works-fine*/
 describe('itier-client-with-iservice-works-fine', function () {
   var client = null;
-
-  var servers = [];
+  var server;
 
   /*{{{ before */
   before(function (done) {
     var mockServer = function (callback) {
-      var count = 2;
-      
-      /*{{{ serverOne */
-      var serverOne = http.createServer(function (req, res) {
-        if (req.url === '/api/tree/' + encodeURIComponent('service_online/iservice')) {
-          res.end(JSON.stringify({
-            error : null,
-            data : {
-              '/service_online' : {
-                'data' : 1234,
-                'meta' : {'v' : 1, 't' : 2}
-              },
-              '/service_online/iservice' : {
-                'data' : 12345,
-                'meta' : {'v' : 1, 't' : 2}
-              },
-              '/service_online/iservice/1.0' : {
-                'data' : 123456,
-                'meta' : {'v' : 1, 't' : 2}
-              },
-              '/service_online/iservice/1.0/1' : {
-                'data' : JSON.stringify({
-                  host : '127.0.0.1',
-                  port : 23432
-                }),
-                'meta' : {'v' : 1, 't' : 2}
-              },
-            }
-          }));
-        } else if (req.url === '/api/watch/' + encodeURIComponent('service_online/iservice')){
-          res.end(JSON.stringify({
-            error : null,
-            data : null
-          }));
-        } else {
-          res.end('');
-        }
-      }).listen(56565, function () {
-        if (--count === 0) {
-          callback();
-        }
-      });
-      servers.push(serverOne);
-      /*}}}*/
 
-      /*{{{ serverTwo */
-      var serverTwo = http.createServer(function (req, res) {
+      /*{{{ server */
+      server = http.createServer(function (req, res) {
         if (req.url === '/api/tree/' + encodeURIComponent('service_online/itier')) {
           res.end(JSON.stringify({
             error : null,
@@ -555,11 +510,8 @@ describe('itier-client-with-iservice-works-fine', function () {
           res.end('');
         }
       }).listen(23432, function () {
-        if (--count === 0) {
-          callback();
-        }
+        callback();
       });
-      servers.push(serverTwo);
       /*}}}*/
 
     }
@@ -569,7 +521,7 @@ describe('itier-client-with-iservice-works-fine', function () {
         'appname' : 'test',
       });
       var obj = client.connectIservice({
-        host : '127.0.0.1:56565',
+        host : '127.0.0.1:23432',
         cache : __dirname + '/run',
         //用户使用时，不设置not_copy
         not_copy : true,
@@ -603,9 +555,7 @@ describe('itier-client-with-iservice-works-fine', function () {
 
   /*{{{ after */
   after(function (done) {
-    servers.forEach(function (server) {
-      server.close();
-    });
+    server.close();
     done();
   });
   /*}}}*/

--- a/test/itier-client-test.js
+++ b/test/itier-client-test.js
@@ -567,19 +567,3 @@ after(function () {
   HTTP.close();
 });
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
itier-client支持iservice-client使用。用组合的方式，itier-client可以自己选择是否要使用iservice-client。减少对itier-client整体结构的侵入。分开使用在降低耦合的同时也使得iservice-client更可控，用户能够更好用
